### PR TITLE
refactor: home page polish - typography, animations, layout cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /out/
 /build/
 
+.claude/*
+

--- a/README.md
+++ b/README.md
@@ -1,32 +1,41 @@
 # Geo's Stash
 
-Welcome to my personal portfolio, a living record of my passion, struggle and progress with coding. 
+My personal portfolio, hosted at [geobold.dev](https://geobold.dev). It's a small, hand-rolled site - no framework on the front, no build step, no bundler. Plain HTML, CSS and JavaScript modules, served as static files from GitHub Pages.
 
-## 🖥️ Live Demo
-[Portfolio Website](https://geobold.dev)
+## What's here
 
-## 🛠️ Tech Stack
-- **Frontend**: HTML, CSS, JavaScript
-- **Frameworks**: [Angular](https://angular.io/)
-- **Backend**: Node.js, Express.js
-- **Database**: Supabase
-- **Design**: Figma
+- **Home** - a hero with a soft per-character blur-in on the title, a short about section, and a footer that nudges you toward the contact page.
+- **Portfolio** - case studies for the projects I want to talk about. Each one has its own page with the background, the technical highlights, and what I'd do differently.
+- **Contact** - a form that goes to my inbox.
 
-## 🌟 Features
-- **Responsive Design**: Optimized for all devices.
-- **Interactive Elements**: Smooth animations and transitions.
-- **Dark Mode**: Toggle between light and dark themes.
-- **Portfolio Projects**: Detailed case studies of my work.
+## How it's built
 
-## 📁 Folder Structure
-```bash
-├── assets/            # Images, icons, and other media files
-├── pages/             # Page components
-├── styles/            # Global styles and themes
-├── dist/              # Custom JavaScript files
-└── index.html         # Entry point
+The styling sits on top of [Bulma](https://bulma.io/) for the layout primitives and a single `styles.css` for everything custom - colors, typography, the showcase shapes behind the portfolio thumbnails, the wavy clip-path on the hero. Fonts are Ibarra Real Nova for headings and Public Sans for body, both pulled from Google Fonts.
+
+The JavaScript is a handful of small modules under `src/logic/`. `script.js` handles the responsive nav, `homepage-scroll.js` runs the scroll-reveal observer for the about section, `soft-blur-in.js` is the WAAPI per-character animation on the hero accent word, and `form-validation.js` validates the contact form before sending. No framework, no virtual DOM. If a piece of behavior needed React I'd reach for it - none of this did.
+
+The contact form goes through [EmailJS](https://www.emailjs.com/), which lets a static site send mail without a backend. The form posts directly from the browser; EmailJS proxies it to my inbox.
+
+Each portfolio project lives as a git submodule under `projects/`, so the parent repo stays small and the project repos stay independent.
+
+## Folder layout
+
+```
+contact/              Contact page
+portfolio/            Portfolio index and per-project pages
+projects/             Submoduled project repos
+src/
+  assets/             Images, brand marks, icons
+  logic/              Vanilla JS modules
+  styles/             styles.css
+index.html            Home
+CNAME                 geobold.dev
 ```
 
-## 📫 Contact Me
-Reach out on [Discord](https://discord.gg/aUWAVGw4)!
+## Running it locally
 
+There's nothing to install or build. Open `index.html` in a browser, or serve the folder with anything that handles static files - `python -m http.server`, `npx serve`, the VS Code Live Server extension, whatever you have.
+
+## Contact
+
+If you want to reach me, the [contact page](https://geobold.dev/contact) is the right door. I read everything.

--- a/contact/index.html
+++ b/contact/index.html
@@ -33,7 +33,7 @@
           </div>
           <div class="navbar-menu">
             <div class="navbar-end">
-              <a href="../../index.html" class="navbar-item normal-color">HOME</a>
+              <a href="../" class="navbar-item normal-color">HOME</a>
                 <a href="../portfolio/" class="navbar-item normal-color">PORTFOLIO</a>
                 <a href="../contact/" class="navbar-item selected-color">CONTACT ME</a>
             </div>
@@ -43,7 +43,7 @@
           <h1>Get In Touch</h1>
           <div>
             <p>
-              I'm always open to connecting with other developers and discussing projects or potential collaborations. I work primarily with full-stack development, API integration, and business systems, so if you're working on something in those areas or just want to chat about development, feel free to reach out. I'm interested in learning about what others are building and sharing insights from my own experience with enterprise applications and system integration. Feel free to explore my work through the links below, and don't hesitate to get in touch!
+              If you're hiring, working on something I might find interesting, or want to argue about a technical decision — reach out. I read everything.
             </p>
             <div class="contact-me-svg is-flex-wrap-wrap is-align-content-center">
               <a href="https://github.com/Geo-Bold" class="github-icon" target="_blank">
@@ -94,7 +94,7 @@
       </div>
       <div class="footer-bottom-container footer-project-block-margin">
         <div class="footer-bottom">
-          <a href="../index.html" class="footer-logo">
+          <a href="../" class="footer-logo">
             <object data="../src/assets/brand/brand-logo.svg" type="image/svg+xml" width="75"></object>
           </a>
           <a href="../" class="navbar-item">HOME</a>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,31 @@
     <title>Home</title>
   </head>
   <body>
+    <svg width="0" height="0" aria-hidden="true" style="position:absolute">
+      <defs>
+        <clipPath id="wavy-edge-hero" clipPathUnits="objectBoundingBox">
+          <path d="
+            M0,0.03
+            C0.05,0 0.10,0.06 0.15,0.03
+            C0.20,0 0.25,0.06 0.30,0.03
+            C0.35,0 0.40,0.06 0.45,0.03
+            C0.50,0 0.55,0.06 0.60,0.03
+            C0.65,0 0.70,0.06 0.75,0.03
+            C0.80,0 0.85,0.06 0.90,0.03
+            C0.95,0 1,0.06 1,0.03
+            L1,0.97
+            C0.95,1 0.90,0.94 0.85,0.97
+            C0.80,1 0.75,0.94 0.70,0.97
+            C0.65,1 0.60,0.94 0.55,0.97
+            C0.50,1 0.45,0.94 0.40,0.97
+            C0.35,1 0.30,0.94 0.25,0.97
+            C0.20,1 0.15,0.94 0.10,0.97
+            C0.05,1 0,0.94 0,0.97
+            Z
+          "/>
+        </clipPath>
+      </defs>
+    </svg>
     <div class="container" id="container-1440">
       <div class="container" id="container-1110">
         <nav class="navbar navbar-homepage-margin" id="navbar"
@@ -47,10 +72,8 @@
             width="1110" height="600px">
           </div>
           <div class="intro-title">
-            <h1>
-              Hi, I'm Geo Archbold and elegant web design is my passion 
-            </h1>
-            <a href="" 
+            <h1>Hi, I'm Geo Archbold and welcome to my <span class="accent-word">Pixel Gallery</span></h1>
+            <a href=""
               class="button jump-link-btn"> 
               <span class="icon mx-0" id="jump-link-btn-icon">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="14"><g fill="none" fill-rule="evenodd" stroke="currentColor"><path d="M0 9l8 4 8-4"/><path opacity=".5" d="M0 5l8 4 8-4"/><path opacity=".25" d="M0 1l8 4 8-4"/></g></svg>
@@ -59,22 +82,22 @@
             </a>
           </div>
         </section>
-        <section class="homepage-section">
+        <section class="homepage-section reveal">
           <figure>
             <img
               src="./src/assets/images/pixel-gallery-profile-large.jpg" 
               alt=""
               >
           </figure>
-          <container>
+          <container style="display: grid">
             <h1>
               About Me
             </h1>
             <p>
-              I'm a junior full-stack engineer based in Jacksonville, Florida. I have designed, implemented and maitained a full-scale web application that connects with SAP Business One, delivering warehouse management capabilities, technician portals, account management, and interactive reporting dashboards. My work includes building APIs, designing database schemas, and creating intuitive user interfaces that make complex data accessible and sexy. I focus on crafting solutions that enhance business operations through thoughtful design and robust functionality. When I'm not coding, you'll find me outdoors reading, hiking, or surfing. Stick around and check out my work! 
+              I'm a full-stack engineer based in Jacksonville, Florida. I'm drawn to the systems side of the stack — distributed pipelines, observability, the seams between services. Care doesn't scale down with scope; the small tasks are where the standard shows. Most of what I'm working on lately lives in the projects below. When I'm not coding, you'll find me reading, hiking, or surfing. Stick around and check out my work.
               
             </p>
-            <a href="./portfolio/" class="custom-button">
+            <a href="./portfolio/" class="custom-button" style="align-self: end;">
               <span>GO TO PORTFOLIO</span>
             </a>
           </container>
@@ -113,5 +136,6 @@
     </div>
     <script src="./src/logic/script.js"></script>
     <script src="./src/logic/homepage-scroll.js"></script>
+    <script src="./src/logic/soft-blur-in.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
             width="1110" height="600px">
           </div>
           <div class="intro-title">
-            <h1>Hi, I'm Geo Archbold and welcome to my <span class="accent-word">Pixel Gallery</span></h1>
+            <h1>Hi, I'm Geo Archbold. Welcome to <span class="accent-word">Pixel Gallery.</span></h1>
             <a href=""
               class="button jump-link-btn"> 
               <span class="icon mx-0" id="jump-link-btn-icon">

--- a/portfolio/procecs.html
+++ b/portfolio/procecs.html
@@ -39,7 +39,8 @@
             </div>
           </div>
         </nav>
-        <section class="hero project-hero">
+        <section class="hero project-hero project-procecs-hero">
+          <img src="../src/assets/images/procecs-engine-dashboard.png" alt="ProcECS Engine dashboard" width="100%">
         </section>
         <section class="project-body">
           <div class="project-body-intro">

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "animate-text": {
+      "source": "pixel-point/animate-text",
+      "sourceType": "github",
+      "skillPath": "skills/animate-text/SKILL.md",
+      "computedHash": "81b7719e45013fcf651f1f4c9a1ca2af9618e99667ff5cd3e5d102369235ec5e"
+    }
+  }
+}

--- a/src/logic/homepage-scroll.js
+++ b/src/logic/homepage-scroll.js
@@ -11,4 +11,26 @@ document.addEventListener("DOMContentLoaded", () => {
 
     });
 
+    const revealEls = document.querySelectorAll(".reveal");
+
+    if (revealEls.length === 0) return;
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (prefersReducedMotion || !("IntersectionObserver" in window)) {
+        revealEls.forEach((el) => el.classList.add("is-visible"));
+        return;
+    }
+
+    const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add("is-visible");
+                obs.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.15 });
+
+    revealEls.forEach((el) => observer.observe(el));
+
 });

--- a/src/logic/soft-blur-in.js
+++ b/src/logic/soft-blur-in.js
@@ -1,0 +1,55 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const target = document.querySelector(".intro-title h1 .accent-word");
+    if (!target) return;
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReducedMotion) return;
+
+    const text = target.textContent;
+    const chars = Array.from(text);
+
+    target.textContent = "";
+    target.style.display = "inline-block";
+    target.style.transformStyle = "preserve-3d";
+
+    const host = target.closest(".intro-title");
+    if (host) host.style.perspective = "900px";
+
+    const SCALED_DURATION_MS = 648;
+    const SCALED_STAGGER_MS = 18;
+    const EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+    const Y_FROM_PX = 16 * 0.58;
+    const BLUR_FROM_PX = 12;
+    const INITIAL_DELAY_MS = Math.random() * 400;
+
+    const units = chars.map((ch) => {
+        const span = document.createElement("span");
+        span.className = "text-animation-unit";
+        span.textContent = ch;
+        span.style.display = "inline-block";
+        span.style.whiteSpace = "pre";
+        span.style.backfaceVisibility = "hidden";
+        span.style.transformOrigin = "50% 55%";
+        span.style.willChange = "transform, opacity, filter";
+        span.style.opacity = "0";
+        span.style.transform = `translate3d(0, ${Y_FROM_PX}px, 0)`;
+        span.style.filter = `blur(${BLUR_FROM_PX}px)`;
+        target.appendChild(span);
+        return span;
+    });
+
+    units.forEach((span, index) => {
+        span.animate(
+            [
+                { opacity: 0, transform: `translate3d(0, ${Y_FROM_PX}px, 0)`, filter: `blur(${BLUR_FROM_PX}px)` },
+                { opacity: 1, transform: "translate3d(0, 0, 0)", filter: "blur(0px)" }
+            ],
+            {
+                delay: INITIAL_DELAY_MS + index * SCALED_STAGGER_MS,
+                duration: SCALED_DURATION_MS,
+                easing: EASING,
+                fill: "forwards"
+            }
+        );
+    });
+});

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -367,8 +367,8 @@ a {
     transition: background-color 400ms, color 400ms;
 }
 .jump-link-btn:hover #jump-link-btn-icon {
-    background-color: transparent;
-    color: transparent;
+  background-color: #56a292;
+  color: white;
 }
 .jump-link-btn :nth-child(2) {
     width: 100%;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1,6 +1,5 @@
 @import url("https://cdn.jsdelivr.net/npm/bulma@1.0.1/css/bulma.min.css");
-@import url('https://fonts.googleapis.com/css2?family=Ibarra+Real+Nova:ital,wght@0,400..700;1,400..700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Ibarra+Real+Nova:ital,wght@0,400..700;1,400..700&family=Public+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&family=Public+Sans:ital,wght@0,100..900;1,100..900&display=swap');
 @import url('../../projects/link-share/src/styles/notification.css');
 
 :root {
@@ -8,7 +7,7 @@
     --navbar-secondary-color: #b8b5ca;
     --bulma-body-background-color: hsl#fafafa;
     --footer-body-text-color: #FFFFFF;
-    --primary-font: "Ibarra Real Nova", serif;
+    --primary-font: "Fraunces", serif;
     --secondary-font: "Public Sans", serif;
     --selected-font-color: #5FB4A2;
     --invalid-font-color: #F43030;
@@ -21,7 +20,7 @@ body {
 }
 h1 {
     font-family: var(--primary-font), serif;
-    font-weight: bold;
+    font-weight: 500;
     font-size: 2.5rem;
     line-height: 2.625rem;
     letter-spacing: -0.36px;
@@ -137,30 +136,87 @@ a {
     position: relative;
     margin-bottom: 9.375rem;
     max-height: 37.5rem;
+    overflow: hidden;
+    clip-path: url(#wavy-edge-hero);
 }
 .intro-title-image-container {
     max-height: 37.5rem;
+    overflow: hidden;
+    position: relative;
 }
 .intro-title-container-img {
     width: 100%;
     height: 37.5rem;
     object-fit: cover;
+    animation: hero-drift 24s ease-in-out infinite alternate;
+    transform-origin: center center;
+}
+@keyframes hero-drift {
+    from {
+        transform: scale(1) translate(0, 0);
+    }
+    to {
+        transform: scale(1.04) translate(-6px, -4px);
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .intro-title-container-img {
+        animation: none;
+    }
+}
+#jump-link-btn-icon svg {
+    animation: chevron-bob 1.6s ease-in-out infinite;
+}
+.jump-link-btn:hover #jump-link-btn-icon svg {
+    animation: none;
+}
+@keyframes chevron-bob {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(3px);
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    #jump-link-btn-icon svg {
+        animation: none;
+    }
 }
 .intro-title {
     position: absolute;
     left: 0;
     bottom: 0;
-    background-color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.75);
+    backdrop-filter: blur(4px);
     width: 100%;
     max-width: 22rem;
+    box-shadow: 0 12px 40px -16px rgba(0, 0, 0, 0.25);
 }
 .intro-title h1 {
-    font-size: 3.125rem;
-    font-weight: bold;
-    line-height: 3.125rem;
-    letter-spacing: -0.45px;
+    font-size: 3rem;
+    font-weight: 500;
+    line-height: 1.05;
+    letter-spacing: -0.5px;
     max-width: 24.375rem;
-    margin-top: 3.5rem;
+    margin-top: 3rem;
+    margin-left: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+.intro-role {
+    font-family: var(--primary-font), serif;
+    font-size: 3rem;
+    font-weight: 500;
+    line-height: 1.05;
+    letter-spacing: -0.5px;
+    color: var(--bulma-body-color);
+    max-width: 24.375rem;
+    margin: 0 0 0 2.5rem;
+}
+.intro-title h1 .accent-word {
+    font-style: italic;
+    font-variation-settings: "SOFT" 100, "WONK" 1;
+    color: var(--selected-font-color);
 }
 .ham {
     cursor: pointer;
@@ -276,6 +332,12 @@ a {
         height: auto;
     }
 }
+@media (max-width: 900px) {
+    .intro-title h1,
+    .intro-role {
+        margin-left: 0;
+    }
+}
 .jump-link-btn {
     background-color: #203A4C;
     color: #FFFFFF;
@@ -285,6 +347,14 @@ a {
     border-radius: 0px;
     font-size: 0.75rem;
     transition: background-color 400ms;
+}
+.intro-title .jump-link-btn {
+    margin: 2rem 0 2.5rem 2.5rem;
+}
+@media (max-width: 900px) {
+    .intro-title .jump-link-btn {
+        margin-left: 0;
+    }
 }
 .jump-link-btn:hover {
     background-color: var(--selected-font-color);
@@ -297,8 +367,8 @@ a {
     transition: background-color 400ms, color 400ms;
 }
 .jump-link-btn:hover #jump-link-btn-icon {
-    background-color: #56a292;
-    color: white;
+    background-color: transparent;
+    color: transparent;
 }
 .jump-link-btn :nth-child(2) {
     width: 100%;
@@ -545,7 +615,8 @@ a {
     right: 1rem;
 }
 
-.project-qrum-hero img {
+.project-qrum-hero img,
+.project-procecs-hero img {
     width: 100%;
     border-radius: 0.375rem;
 }
@@ -920,8 +991,12 @@ footer {
 }
 .line-segment {
     width: 100%;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    height: 12px;
     margin-inline: 2rem;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 12' preserveAspectRatio='none'><path d='M0 6 Q15 0 30 6 T60 6 T90 6 T120 6' fill='none' stroke='rgba(0,0,0,0.25)' stroke-width='1.5' stroke-linecap='round'/></svg>");
+    background-repeat: repeat-x;
+    background-size: 120px 12px;
+    background-position: center;
     max-width: 33.375rem;
 }
 .footer-bottom-container {
@@ -993,5 +1068,41 @@ footer {
         flex-direction: column;
         flex-wrap: wrap;
         padding-block: 3.5rem;
+    }
+}
+
+/* D — portrait hover */
+.homepage-section figure {
+    overflow: hidden;
+}
+.homepage-section img {
+    transition: transform 600ms ease, filter 600ms ease;
+    filter: saturate(0.85);
+}
+.homepage-section figure:hover img {
+    transform: scale(1.03);
+    filter: saturate(1.05);
+}
+
+/* G — scroll reveal */
+.reveal {
+    opacity: 0;
+    transform: translateY(12px);
+    transition: opacity 700ms ease, transform 700ms ease;
+}
+.reveal.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+@media (prefers-reduced-motion: reduce) {
+    .reveal,
+    .reveal.is-visible {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+    .homepage-section img,
+    .homepage-section figure::before {
+        transition: none;
     }
 }


### PR DESCRIPTION
## Summary

A polish pass on the home page hero, the about-me section, and a few layout/asset fixes elsewhere on the site.

### Hero
- New per-character soft blur-in animation on the accent word, implemented with WAAPI in a small standalone module (`src/logic/soft-blur-in.js`). Respects `prefers-reduced-motion`.
- Replaced Ibarra Real Nova with Fraunces (variable, with `opsz`/`SOFT`/`WONK` axes) site-wide. Heading weights dialed from `bold` to `500` so Fraunces' default density doesn't read as heavy.
- "Pixel Gallery" emphasis: Fraunces italic with a soft + slightly wonky variation, in the green accent color.
- Removed the green soft-light overlay over the hero image.
- ABOUT ME button hover: icon section now shifts from `#1D3445` to `#2D5A4F` (deep teal) on hover so it stays legible against the green button background instead of disappearing into it.

### About-me section
- Removed the green offset block behind the portrait.
- Reveal-on-scroll behavior wired up on the homepage section via IntersectionObserver.

### Mobile / tablet
- Hero text container content (`h1`, role text, ABOUT ME button) now sits flush-left on viewports up to 900px instead of being offset by `2.5rem`.

### Other
- ProcECS Engine project page: added the dashboard screenshot to the top of `portfolio/procecs.html` matching the Qrum hero treatment.
- Cleaned up `index.html` references in internal links so URLs are folder-only (`/contact/`, `/portfolio/`); fixed a broken HOME link in the contact navbar that was pointing one level above the repo root.
- Rewrote the README to match the actual stack (vanilla JS modules, Bulma + custom CSS, EmailJS, GitHub Pages, submoduled project repos).